### PR TITLE
Makefile: entries for `deps` and `clean-deps`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,21 @@ CASK_EXEC ?= cask exec
 
 all: test
 
-test: clean-elc
+deps:
+	cask install
+
+test: clean-elc deps
 	${CASK_EXEC} ${EMACS} -Q --batch -L . -l window-purpose-test.el --eval '(progn (set-frame-width nil 80) (set-frame-height nil 24))' -f ert-run-tests-batch-and-exit
 
 compile:
 	${CASK_EXEC} ${EMACS} -Q --batch -f batch-byte-compile window-purpose.el
 
+clean: clean-elc clean-deps
+
 clean-elc:
 	rm -f *.elc
 
-.PHONY: all test
+clean-deps:
+	rm -rf .cask/
+
+.PHONY: all test clean


### PR DESCRIPTION
Testing is dependent on having Cask dependencies installed in the
`.cask` directory. Having a Makefile entry to run `cask install`
provides a unified interface for dependency installation that's in line
with testing, building, etc. Similar for `clean-deps`.

Similarly, since testing requires these dependecy packages, `make test`
should also make `deps` prior to running the tests.