### PR TITLE
set-window-purpose: interface for completion

### DIFF
--- a/window-purpose-layout.el
+++ b/window-purpose-layout.el
@@ -383,10 +383,13 @@ Use INDEX=0 for most recent."
 With prefix argument (DONT-DEDICATE is non-nil), don't dedicate the
 window.  Changing the window's purpose is done by displaying a buffer of
 the right purpose in it, or creating a dummy buffer."
-  (interactive "SPurpose: \nP")
+  (interactive
+    (mapcar 'intern
+      (list (completing-read "Purpose: " (purpose-get-all-purposes) nil 'confirm))))
   (purpose--set-window-buffer purpose)
-  (unless dont-dedicate
-    (purpose-set-window-purpose-dedicated-p nil t)))
+  (let ((dont-dedicate current-prefix-arg))
+    (unless dont-dedicate
+      (purpose-set-window-purpose-dedicated-p nil t))))
 
 (defun purpose--delete-window-at (window-getter &optional frame)
   "Delete window returned by WINDOW-GETTER.

--- a/window-purpose-layout.el
+++ b/window-purpose-layout.el
@@ -384,12 +384,12 @@ With prefix argument (DONT-DEDICATE is non-nil), don't dedicate the
 window.  Changing the window's purpose is done by displaying a buffer of
 the right purpose in it, or creating a dummy buffer."
   (interactive
-    (mapcar 'intern
-      (list (completing-read "Purpose: " (purpose-get-all-purposes) nil 'confirm))))
+    (list (intern (completing-read "Purpose: "
+                    (purpose-get-all-purposes) nil 'confirm))
+      (prefix-numeric-value current-prefix-arg)))
   (purpose--set-window-buffer purpose)
-  (let ((dont-dedicate current-prefix-arg))
-    (unless dont-dedicate
-      (purpose-set-window-purpose-dedicated-p nil t))))
+  (unless dont-dedicate
+    (purpose-set-window-purpose-dedicated-p nil t)))
 
 (defun purpose--delete-window-at (window-getter &optional frame)
   "Delete window returned by WINDOW-GETTER.

--- a/window-purpose-utils.el
+++ b/window-purpose-utils.el
@@ -25,6 +25,8 @@
 
 ;;; Code:
 
+(require 'subr-x)
+
 (defcustom purpose-message-on-p nil
   "If non-nil, `purpose-message' will produce a message.
 Toggling this on will cause Purpose to produce some debug messages."
@@ -155,6 +157,15 @@ SYMBOL, WHERE and NAME have the same meaning as in
        (ad-disable-advice ,symbol ',(purpose-advice-convert-where-arg where) ,name)
        (ad-update ,symbol))))
 
+(defun purpose-get-all-purposes ()
+  (delete-dups
+    (append
+      (hash-table-values purpose--default-name-purposes)
+      (hash-table-values purpose--default-mode-purposes)
+      (hash-table-values purpose--default-regexp-purposes)
+      (mapcar 'cdr purpose-user-mode-purposes)
+      (mapcar 'cdr purpose-user-name-purposes)
+      (mapcar 'cdr purpose-user-regexp-purposes))))
 
 (provide 'window-purpose-utils)
 ;;; window-purpose-utils.el ends here


### PR DESCRIPTION
In response to #45, we define a function `purpose-get-all-purposes`,
which is then used to get a list of symbol candidates for a call to
`completing-read` within `purpose-set-window-purpose`, improving the
interface for `purpose-set-window-purpose' drastically.