### PR TITLE
set-window-purpose: interface for completion

### DIFF
--- a/window-purpose-core.el
+++ b/window-purpose-core.el
@@ -42,16 +42,6 @@
 
 
 ;;; utilities
-(defun purpose--iter-hash (function table)
-  "Like `maphash', but return a list the results of calling FUNCTION
-for each entry in hash-table TABLE."
-  (let (results)
-    (maphash #'(lambda (key value)
-		 (setq results
-		       (append results
-			       (list (funcall function key value)))))
-	     table)
-    results))
 
 (defun purpose--buffer-major-mode (buffer-or-name)
   "Return the major mode of BUFFER-OR-NAME."

--- a/window-purpose-layout.el
+++ b/window-purpose-layout.el
@@ -383,7 +383,10 @@ Use INDEX=0 for most recent."
 With prefix argument (DONT-DEDICATE is non-nil), don't dedicate the
 window.  Changing the window's purpose is done by displaying a buffer of
 the right purpose in it, or creating a dummy buffer."
-  (interactive "SPurpose: \nP")
+  (interactive
+    (list (intern (completing-read "Purpose: "
+                    (purpose-get-all-purposes) nil 'confirm))
+      (prefix-numeric-value current-prefix-arg)))
   (purpose--set-window-buffer purpose)
   (unless dont-dedicate
     (purpose-set-window-purpose-dedicated-p nil t)))

--- a/window-purpose-utils.el
+++ b/window-purpose-utils.el
@@ -155,6 +155,21 @@ SYMBOL, WHERE and NAME have the same meaning as in
        (ad-disable-advice ,symbol ',(purpose-advice-convert-where-arg where) ,name)
        (ad-update ,symbol))))
 
+(defun purpose-get-all-purposes ()
+  (cl-flet
+    ((hash-table-values (hashtable)
+       "Return all values in HASHTABLE."
+       (let (allvals)
+         (maphash (lambda (kk vv) (setq allvals (cons vv allvals)))
+           hashtable) allvals)))
+    (delete-dups
+      (append
+        (hash-table-values purpose--default-name-purposes)
+        (hash-table-values purpose--default-mode-purposes)
+        (hash-table-values purpose--default-regexp-purposes)
+        (mapcar 'cdr purpose-user-mode-purposes)
+        (mapcar 'cdr purpose-user-name-purposes)
+        (mapcar 'cdr purpose-user-regexp-purposes)))))
 
 (provide 'window-purpose-utils)
 ;;; window-purpose-utils.el ends here

--- a/window-purpose-utils.el
+++ b/window-purpose-utils.el
@@ -176,12 +176,16 @@ for each entry in hash-table TABLE."
 (defun purpose-get-all-purposes ()
     (delete-dups
       (append
+        ;; FIXME: DRY
         (purpose-hash-table-values purpose--default-name-purposes)
         (purpose-hash-table-values purpose--default-mode-purposes)
         (purpose-hash-table-values purpose--default-regexp-purposes)
-        (mapcar 'cdr purpose-user-mode-purposes)
-        (mapcar 'cdr purpose-user-name-purposes)
-        (mapcar 'cdr purpose-user-regexp-purposes))))
+        (purpose-hash-table-values purpose--extended-name-purposes)
+        (purpose-hash-table-values purpose--extended-mode-purposes)
+        (purpose-hash-table-values purpose--extended-regexp-purposes)
+        (purpose-hash-table-values purpose--user-mode-purposes)
+        (purpose-hash-table-values purpose--user-name-purposes)
+        (purpose-hash-table-values purpose--user-regexp-purposes))))
 
 (provide 'window-purpose-utils)
 ;;; window-purpose-utils.el ends here

--- a/window-purpose-utils.el
+++ b/window-purpose-utils.el
@@ -171,9 +171,7 @@ for each entry in hash-table TABLE."
     #'hash-table-values
     (lambda (hash-table)
       "Return all values in HASH-TABLE."
-      (let (allvals)
-        (maphash (lambda (kk vv) (setq allvals (cons vv allvals)))
-          hash-table) allvals))))
+        (purpose--iter-hash (lambda (kk vv) vv) hash-table))))
 
 (defun purpose-get-all-purposes ()
     (delete-dups

--- a/window-purpose-utils.el
+++ b/window-purpose-utils.el
@@ -155,23 +155,24 @@ SYMBOL, WHERE and NAME have the same meaning as in
        (ad-disable-advice ,symbol ',(purpose-advice-convert-where-arg where) ,name)
        (ad-update ,symbol))))
 
+(defalias 'purpose-hash-table-values
+  (if (fboundp 'hash-table-values)
+    #'hash-table-values
+    (lambda (hash-table)
+      "Return all values in HASH-TABLE."
+      (let (allvals)
+        (maphash (lambda (kk vv) (setq allvals (cons vv allvals)))
+          hash-table) allvals))))
+
 (defun purpose-get-all-purposes ()
-  ;; subr-x.el has a function to get all values from a hashtable, but subr-x.el
-  ;; is not included in Emacs < 24.4, making this defun necessary
-  (cl-flet
-    ((hash-table-values (hashtable)
-       "Return all values in HASHTABLE."
-       (let (allvals)
-         (maphash (lambda (kk vv) (setq allvals (cons vv allvals)))
-           hashtable) allvals)))
     (delete-dups
       (append
-        (hash-table-values purpose--default-name-purposes)
-        (hash-table-values purpose--default-mode-purposes)
-        (hash-table-values purpose--default-regexp-purposes)
+        (purpose-hash-table-values purpose--default-name-purposes)
+        (purpose-hash-table-values purpose--default-mode-purposes)
+        (purpose-hash-table-values purpose--default-regexp-purposes)
         (mapcar 'cdr purpose-user-mode-purposes)
         (mapcar 'cdr purpose-user-name-purposes)
-        (mapcar 'cdr purpose-user-regexp-purposes)))))
+        (mapcar 'cdr purpose-user-regexp-purposes))))
 
 (provide 'window-purpose-utils)
 ;;; window-purpose-utils.el ends here

--- a/window-purpose-utils.el
+++ b/window-purpose-utils.el
@@ -155,6 +155,17 @@ SYMBOL, WHERE and NAME have the same meaning as in
        (ad-disable-advice ,symbol ',(purpose-advice-convert-where-arg where) ,name)
        (ad-update ,symbol))))
 
+(defun purpose--iter-hash (function table)
+  "Like `maphash', but return a list the results of calling FUNCTION
+for each entry in hash-table TABLE."
+  (let (results)
+    (maphash #'(lambda (key value)
+		 (setq results
+		       (append results
+			       (list (funcall function key value)))))
+	     table)
+    results))
+
 (defalias 'purpose-hash-table-values
   (if (fboundp 'hash-table-values)
     #'hash-table-values

--- a/window-purpose-utils.el
+++ b/window-purpose-utils.el
@@ -156,6 +156,8 @@ SYMBOL, WHERE and NAME have the same meaning as in
        (ad-update ,symbol))))
 
 (defun purpose-get-all-purposes ()
+  ;; subr-x.el has a function to get all values from a hashtable, but subr-x.el
+  ;; is not included in Emacs < 24.4, making this defun necessary
   (cl-flet
     ((hash-table-values (hashtable)
        "Return all values in HASHTABLE."


### PR DESCRIPTION
This is a continuation of PR #47, which I closed due to Github bugging out and not responding to my new commits to the branch.

In response to #45, we define a function `purpose-get-all-purposes', which is then used to
get a list of symbol candidates for a call to `completing-read' within
`purpose-set-window-purpose', improving the interface for
`purpose-set-window-purpose' drastically.