### PR TITLE
Default to edit for buffers visiting files

### DIFF
--- a/test/core-test.el
+++ b/test/core-test.el
@@ -261,6 +261,22 @@ The prompt is chosen according to `purpose-preferred-prompt'."
   (purpose-insert-user-input "foo")
   (should (equal (purpose-read-purpose "Purpose: " '(foo bar baz)) 'foo)))
 
+(ert-deftest purpose-test-default-purpose-when-visiting-file ()
+  "Test that the default purpose for a buffer visiting a file is 'edit.
+Also test that if there was a predefined purpose for that buffer
+it gets that one, and that the default purpose for a buffer not
+visiting a file is still `default-purpose'."
+  (unwind-protect
+      (purpose-with-temp-config
+       nil '(("foo" . yolo)) nil
+       (find-file "foo")
+       (should (equal (purpose-buffer-purpose (get-buffer "foo")) 'yolo))
+       (find-file "bar")
+       (should (equal (purpose-buffer-purpose (get-buffer "bar")) 'edit))
+       (get-buffer-create "baz")
+       (should (equal (purpose-buffer-purpose (get-buffer "baz")) default-purpose))
+       (purpose-kill-buffers-safely "foo" "bar" "baz"))))
+
 (provide 'core-test)
 
 ;;; core-test.el ends here

--- a/window-purpose-core.el
+++ b/window-purpose-core.el
@@ -40,6 +40,12 @@
   :type 'symbol
   :package-version "1.2")
 
+(defcustom default-file-purpose 'edit
+  "The default purpose for buffers visiting a file which didn't get a purpose."
+  :group 'purpose
+  :type 'symbol
+  :package-version "1.2")
+
 (defcustom purpose-preferred-prompt 'auto
   "Which interface should Purpose use when prompting the user.
 Available options are: 'auto - use IDO when `ido-mode' is enabled,
@@ -212,6 +218,9 @@ If no purpose was determined, return `default-purpose'."
      (purpose--buffer-purpose-mode buffer-or-name
                                    purpose--default-mode-purposes)))
 
+   ;; If the buffer is visiting a file, fallback to 'edit purpose
+   (when (buffer-file-name (get-buffer buffer-or-name))
+     default-file-purpose)
    ;; fallback to default purpose
    default-purpose))
 


### PR DESCRIPTION
As discussed in #113, implementing tests for this is still needed.

I tested it manually and

- the buffers that usually open in `'edit` are still in `'edit`
- `*magit: blah*` still gets `'general`
- if I create a file (`SPC ff RET blablabla RET` in Spacemacs it nicely gets `'edit`
- if I create a buffer (`spacemacs/new-empty-buffer`) with a random name it nicely gets `'general`
