### PR TITLE
Improve code1 dired

### DIFF
--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -132,29 +132,31 @@ If a non-buffer-dedicated window with purpose 'dired exists, display
 the directory of the current buffer in that window, using `dired'.
 If there is no window available, do nothing.
 If current buffer doesn't have a filename, do nothing."
-(save-selected-window
+  (save-selected-window
     (let ((file-path (buffer-file-name)))
       (when (and file-path
                  (cl-delete-if #'window-dedicated-p
                                (purpose-windows-with-purpose 'code1-dired)))
-        ;; Prevents immediately closing the newly created popup help window
-        (letf (((symbol-value 'purpose-select-buffer-hook) nil))
-          (let ((buffer (dired-noselect (file-name-directory file-path))))
-            ;; Make sure code1 only creates 1 dired buffer
-            (dolist (other-buf (purpose-buffers-with-purpose 'code1-dired))
-              (when (and (not (eq buffer other-buf))
-                         (not (string= (buffer-name other-buf)
-                                       (purpose--dummy-buffer-name 'code1-dired))))
-                (kill-buffer other-buf)))
-            (with-current-buffer buffer
-              (rename-buffer purpose-x-code1-dired-buffer-name))
-            (switch-to-buffer buffer)
-            (dired-goto-file file-path)
-            (when (fboundp 'dired-hide-details-mode)
-              (when (not (assq 'dired-hide-details-mode minor-mode-alist))
-                (add-minor-mode 'dired-hide-details-mode ""))
-              (dired-hide-details-mode))
-            (bury-buffer (current-buffer))))))))
+        (let ((buffer (dired-noselect (file-name-directory file-path))))
+          ;; Make sure code1 only creates 1 dired buffer
+          (dolist (other-buf (purpose-buffers-with-purpose 'code1-dired))
+            (when (and (not (eq buffer other-buf))
+                       (not (string= (buffer-name other-buf)
+                                     (purpose--dummy-buffer-name 'code1-dired))))
+              (kill-buffer other-buf)))
+          (with-current-buffer buffer
+            (rename-buffer purpose-x-code1-dired-buffer-name))
+          ;; Prevents immediately closing the newly created popup help window
+          (letf (((symbol-value 'purpose-select-buffer-hook) nil))
+            (switch-to-buffer buffer))
+          ;; Move point to the line in the dired buffer showing the current
+          ;; buffer's file on every update
+          (dired-goto-file file-path)
+          (when (fboundp 'dired-hide-details-mode)
+            (when (not (assq 'dired-hide-details-mode minor-mode-alist))
+              (add-minor-mode 'dired-hide-details-mode ""))
+            (dired-hide-details-mode))
+          (bury-buffer (current-buffer)))))))
 
 (defun purpose-x-code1-update-changed ()
   "Update auxiliary buffers if frame/buffer had changed.

--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -55,7 +55,7 @@
   "The buffer name used for the `dired' buffer specific to Code1 extension."
   :group 'purpose
   :type '(string)
-  :package-version "1.5")
+  :package-version "1.6.2")
 
 (defvar purpose-x-code1--window-layout
   '(nil

--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -151,6 +151,8 @@ If current buffer doesn't have a filename, do nothing."
             (switch-to-buffer buffer)
             (dired-goto-file file-path)
             (when (fboundp 'dired-hide-details-mode)
+              (when (not (assq 'dired-hide-details-mode minor-mode-alist))
+                (add-minor-mode 'dired-hide-details-mode ""))
               (dired-hide-details-mode))
             (bury-buffer (current-buffer))))))))
 

--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -158,7 +158,10 @@ If current buffer doesn't have a filename, do nothing."
   "Update auxiliary buffers if frame/buffer had changed.
 Uses `frame-or-buffer-changed-p' to determine whether the frame or
 buffer had changed."
-  (when (frame-or-buffer-changed-p 'purpose-x-code1-buffers-changed)
+  (when (and
+         (frame-or-buffer-changed-p 'purpose-x-code1-buffers-changed)
+         (not (memq (purpose-buffer-purpose (current-buffer)) '(code1-dired buffers ilist)))
+         (not (minibufferp)))
     (purpose-x-code1-update-dired)
     (imenu-list-update-safe)))
 

--- a/window-purpose.el
+++ b/window-purpose.el
@@ -7,7 +7,7 @@
 ;; Version: 1.6.1
 ;; Keywords: frames
 ;; Homepage: https://github.com/bmag/emacs-purpose
-;; Package-Requires: ((emacs "24") (cl-lib "0.5") (let-alist "1.0.3") (imenu-list "0.1"))
+;; Package-Requires: ((emacs "24") (cl-lib "0.5") (let-alist "1.0.3") (imenu-list "0.1") (shut-up "0.3.2"))
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
This PR improves usability of the code1 extension by making the following changes:

1. Fix bug where updating dired would interfere with the first popup window. Specifically, there's a bug now when code1 and popwin extensions are used together, when the popwin-display-buffer creates the first ever popup window, the frame or buffer change will create a new dired buffer, which gets selected, which triggers the newly installed `purpose-select-buffer-hook`, and closes the new popup window immediately.

2. Allow multiple dired windows to coexist under the code1 layout. Right now all dired buffers are displayed in the dired window. This is often annoying as one often wants to open a bigger dired window to batch process files while keeping the smaller one for reading.

3. It doesn't make sense to update dired and imenu-list when focusing on a window in which there's no meaningul info to provide to dired and imenu. This PR short circuits such situations.

4. As of emacs 25.3.3, `dired-hide-details-mode` as defined in `dired.el` does not set a lighter and a keymap, thus this mode is not added into `minor-mode-alist`, so if one is using `desktop-save-mode`, on the next launch of emacs, the dired buffer will show all of the details again. This PR detects if `dired-hide-details-mode` is in `minor-mode-alist`. If not, add it there so desktop can persist this minor mode into the desktop file.

Happy New Year!
  