### PR TITLE
Prefer the selected window even with multiple frames

### DIFF
--- a/window-purpose-switch.el
+++ b/window-purpose-switch.el
@@ -248,6 +248,12 @@ terminal if it's non-nil."
                       reusable-frames)
              nil)))))
 
+(defun purpose--pick-selected-or-any-window (windows)
+  (let ((selected (selected-window)))
+    (if (member selected windows)
+        selected
+      (car windows))))
+
 (defun purpose-display-reuse-window-buffer (buffer alist)
   "Return a window that is already displaying BUFFER.
 Return nil if no usable window is found.
@@ -281,7 +287,7 @@ that frame."
                      windows))
       (when .inhibit-same-window
         (setq windows (delq (selected-window) windows)))
-      (setq window (car windows))
+      (setq window (purpose--pick-selected-or-any-window windows))
       (when window
         (purpose-change-buffer buffer window 'reuse alist))
       window)))
@@ -321,7 +327,7 @@ that a window on another frame is chosen, avoid raising that frame."
                      windows))
       (when .inhibit-same-window
         (setq windows (delq (selected-window) windows)))
-      (setq window (car windows))
+      (setq window (purpose--pick-selected-or-any-window windows))
       (when window
         (purpose-change-buffer buffer window 'reuse alist))
       window)))


### PR DESCRIPTION
When the functions `purpose-display-reuse-window-buffer` and `purpose-display-reuse-window-purpose` have multiple windows to choose from, they should prefer the selected window. This worked for a single frame, and now it also works over multiple frames.

The issue i had can be reproduced with GNU Emacs 25.3.2 as follows:
1. Start `emacs -Q` from the
2. Evaluate these statements:
   ```elisp
    (require 'cask "~/.cask/cask.el")
    (cask-initialize)
    (add-to-list 'load-path ".")  ;; I started emacs from the window-purpose folder
    (require 'window-purpose)
    (purpose-mode)

    (add-to-list 'display-buffer-alist
                 '("." nil (reusable-frames . t)))

    (set-frame-name "FIRST FRAME")
    (make-frame '((name . "SECOND FRAME")))
    ```
    We should have two frames with names "FIRST FRAME" and "SECOND FRAME", both have a "*scratch*" buffer open with purpose `[edit]`.
3. From the **first** frame, use `C-x C-f` to call `purpose-find-file-overload` and select a file.

The file is now opened in the second frame, but i expected it to open in the first one.
