### PR TITLE
Better integration with Ivy

### DIFF
--- a/window-purpose-switch.el
+++ b/window-purpose-switch.el
@@ -1016,7 +1016,7 @@ If Purpose is active (`purpose--active-p' is non-nil), call
 (defmacro without-purpose (&rest body)
   "Make Purpose inactive while executing BODY.
 This works internally by temporarily setting `purpose--active-p'."
-  (declare (indent defun) (debug body))
+  (declare (indent 0) (debug body))
   `(let ((purpose--active-p nil))
      ,@body))
 

--- a/window-purpose-switch.el
+++ b/window-purpose-switch.el
@@ -1025,10 +1025,13 @@ This works internally by temporarily setting `purpose--active-p'."
 This works internally by using `without-purpose' and
 `call-interactively'."
   (declare (indent defun) (debug function-form))
-  `(lambda ()
-     (interactive)
-     (without-purpose
-       (call-interactively ,command))))
+  (let ((command-sym (cl-gensym)))
+    `(lambda ()
+       (interactive)
+       (without-purpose
+         (let ((,command-sym ,command))
+           (call-interactively (or (command-remapping ,command-sym)
+                                   ,command-sym)))))))
 
 
 

--- a/window-purpose.el
+++ b/window-purpose.el
@@ -63,6 +63,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'easymenu)
 (require 'window-purpose-utils)
 (require 'window-purpose-configuration)
@@ -90,9 +91,14 @@ it calls OTHER-FN interactively.
 Example:
   (purpose-ido-caller #'ido-find-file #'find-file)"
   (declare (indent nil) (debug (function-form function-form)))
-  `(lambda (&rest _args)
-     (interactive)
-     (call-interactively (if ido-mode ,ido-fn ,other-fn))))
+  (let ((other-fn-sym (cl-gensym)))
+    `(lambda (&rest _args)
+       (interactive)
+       (call-interactively (if ido-mode
+                               ,ido-fn
+                             (let ((,other-fn-sym ,other-fn))
+                               (or (command-remapping ,other-fn-sym)
+                                   ,other-fn-sym)))))))
 
 (defalias 'purpose-friendly-find-file
   (purpose-ido-caller #'ido-find-file #'find-file)


### PR DESCRIPTION
When `ivy-mode` is on, [Ivy][] uses [command remapping][] to remap `switch-to-buffer` to `ivy-switch-to-buffer`.  However, if you enable `purpose-mode`, `C-x b` is rebound to `purpose-switch-buffer-overload`, which will end up effectively doing `(call-interactively 'switch-to-buffer)`, bypassing Ivy's remapping and thus losing some of Ivy's functionality.

[Ivy]: https://github.com/abo-abo/swiper#ivy
[command remapping]: https://www.gnu.org/software/emacs/manual/html_node/elisp/Remapping-Commands.html

The two changes in this PR augment the existing `call-interactively` uses in Purpose to use remapped commands when present, or else the original command if no remapping is configured.

In case you're wondering how I stumbled upon this, `ivy-switch-buffer` has extra actions when you hit e.g. `M-o`, such as the ability to kill a buffer.  I noticed that turning `purpose-mode` on lost those extra actions.

Thank you for writing and maintaining Purpose!