### PR TITLE
Fix over consing

### DIFF
--- a/window-purpose-core.el
+++ b/window-purpose-core.el
@@ -79,12 +79,13 @@ dummy buffer with the purpose 'edit."
 mode and MODE-CONF.
 MODE-CONF is a hash table mapping modes to purposes."
   (when (get-buffer buffer-or-name)     ; check if buffer exists
-    (let* ((major-mode (purpose--buffer-major-mode buffer-or-name))
-           (derived-modes (purpose--iter-hash #'(lambda (mode _purpose) mode)
-                                              mode-conf))
-           (derived-mode (apply #'derived-mode-p derived-modes)))
-      (when derived-mode
-        (gethash derived-mode mode-conf)))))
+    (cl-block nil
+      (maphash
+       (let ((buffer-mode (purpose--buffer-major-mode buffer-or-name)))
+         #'(lambda (mode purpose)
+             (when (provided-mode-derived-p buffer-mode mode)
+               (cl-return purpose))))
+       mode-conf))))
 
 (defun purpose--buffer-purpose-name (buffer-or-name name-conf)
   "Return the purpose of buffer BUFFER-OR-NAME, as determined by its
@@ -107,13 +108,14 @@ regexp REGEXP."
   "Return the purpose of buffer BUFFER-OR-NAME, as determined by the
 regexps matched by its name.
 REGEXP-CONF is a hash table mapping name regexps to purposes."
-  (car (remove nil
-               (purpose--iter-hash
-                #'(lambda (regexp purpose)
-                    (purpose--buffer-purpose-name-regexp-1 buffer-or-name
-                                                           regexp
-                                                           purpose))
-                regexp-conf))))
+  (cl-block nil
+    (maphash
+     #'(lambda (regexp purpose)
+         (when (purpose--buffer-purpose-name-regexp-1 buffer-or-name
+                                                      regexp
+                                                      purpose)
+           (cl-return purpose)))
+     regexp-conf)))
 
 (defun purpose-buffer-purpose (buffer-or-name)
   "Get the purpose of buffer BUFFER-OR-NAME.
@@ -168,7 +170,7 @@ If no purpose was determined, return `default-purpose'."
 
 (defun purpose-buffers-with-purpose (purpose)
   "Return a list of all existing buffers with purpose PURPOSE."
-  (cl-remove-if-not #'(lambda (buffer)
+  (cl-delete-if-not #'(lambda (buffer)
                         (and (eql purpose (purpose-buffer-purpose buffer))
                              (not (minibufferp buffer))))
                     (buffer-list)))

--- a/window-purpose-core.el
+++ b/window-purpose-core.el
@@ -107,13 +107,13 @@ regexp REGEXP."
   "Return the purpose of buffer BUFFER-OR-NAME, as determined by the
 regexps matched by its name.
 REGEXP-CONF is a hash table mapping name regexps to purposes."
-  (cl-block nil
+  (catch found
     (maphash
      #'(lambda (regexp purpose)
          (when (purpose--buffer-purpose-name-regexp-1 buffer-or-name
                                                       regexp
                                                       purpose)
-           (cl-return purpose)))
+           (throw 'found purpose)))
      regexp-conf)))
 
 (defun purpose-buffer-purpose (buffer-or-name)

--- a/window-purpose-core.el
+++ b/window-purpose-core.el
@@ -79,13 +79,12 @@ dummy buffer with the purpose 'edit."
 mode and MODE-CONF.
 MODE-CONF is a hash table mapping modes to purposes."
   (when (get-buffer buffer-or-name)     ; check if buffer exists
-    (cl-block nil
-      (maphash
-       (let ((buffer-mode (purpose--buffer-major-mode buffer-or-name)))
-         #'(lambda (mode purpose)
-             (when (provided-mode-derived-p buffer-mode mode)
-               (cl-return purpose))))
-       mode-conf))))
+    (let* ((major-mode (purpose--buffer-major-mode buffer-or-name))
+           (derived-modes (purpose--iter-hash #'(lambda (mode _purpose) mode)
+                                              mode-conf))
+           (derived-mode (apply #'derived-mode-p derived-modes)))
+      (when derived-mode
+        (gethash derived-mode mode-conf)))))
 
 (defun purpose--buffer-purpose-name (buffer-or-name name-conf)
   "Return the purpose of buffer BUFFER-OR-NAME, as determined by its

--- a/window-purpose-core.el
+++ b/window-purpose-core.el
@@ -107,7 +107,7 @@ regexp REGEXP."
   "Return the purpose of buffer BUFFER-OR-NAME, as determined by the
 regexps matched by its name.
 REGEXP-CONF is a hash table mapping name regexps to purposes."
-  (catch found
+  (catch 'found
     (maphash
      #'(lambda (regexp purpose)
          (when (purpose--buffer-purpose-name-regexp-1 buffer-or-name

--- a/window-purpose-utils.el
+++ b/window-purpose-utils.el
@@ -105,9 +105,7 @@ Example:
 for each entry in hash-table TABLE."
   (let (results)
     (maphash #'(lambda (key value)
-                 (setq results
-                       (append results
-                               (list (funcall function key value)))))
+                 (push (funcall function key value) results))
              table)
     results))
 

--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -653,13 +653,22 @@ This function removes the buffer denoted by BUFFER-OR-NAME from all
 window-local buffer lists."
   (interactive "bBuffer to replace: ")
   (let* ((buffer (window-normalize-buffer buffer-or-name))
-         (purpose (purpose-buffer-purpose buffer))
-         (other-buffers (delete buffer (purpose-buffers-with-purpose purpose))))
+         ;; Delay calculating other-buffers until we need it
+         ;; This prevents unnecessary calculations on temporary
+         ;; buffers created by `with-temp-buffer' and other likewise
+         ;; non-displayed buffers
+         (have-other-buffers nil)
+         (other-buffers nil))
     (dolist (window (window-list-1 nil nil t))
       (if (eq (window-buffer window) buffer)
           (unless (window--delete window t t)
-            (let ((dedicated (purpose-window-purpose-dedicated-p window))
-                  (deletable (window-deletable-p window)))
+            (let* ((purpose (purpose-buffer-purpose buffer))
+                   (other-buffers (if have-other-buffers
+                                      other-buffers
+                                    (setq have-other-buffers t
+                                          other-buffers (delete buffer (purpose-buffers-with-purpose purpose)))))
+                   (dedicated (purpose-window-purpose-dedicated-p window))
+                   (deletable (window-deletable-p window)))
               (cond
                ((and dedicated other-buffers)
                 ;; dedicated, so replace with a buffer with the same purpose

--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -657,18 +657,17 @@ window-local buffer lists."
          ;; This prevents unnecessary calculations on temporary
          ;; buffers created by `with-temp-buffer' and other likewise
          ;; non-displayed buffers
-         (have-other-buffers nil)
+         (other-buffers-calculated nil)
          (other-buffers nil))
     (dolist (window (window-list-1 nil nil t))
       (if (eq (window-buffer window) buffer)
           (unless (window--delete window t t)
             (let* ((purpose (purpose-buffer-purpose buffer))
-                   (other-buffers (if have-other-buffers
-                                      other-buffers
-                                    (setq have-other-buffers t
-                                          other-buffers (delete buffer (purpose-buffers-with-purpose purpose)))))
                    (dedicated (purpose-window-purpose-dedicated-p window))
                    (deletable (window-deletable-p window)))
+              (unless other-buffers-calculated
+                (setq other-buffers (delete buffer (purpose-buffers-with-purpose purpose))
+                      other-buffers-calculated t))
               (cond
                ((and dedicated other-buffers)
                 ;; dedicated, so replace with a buffer with the same purpose


### PR DESCRIPTION
This fixes #149 

The main fix is to not calculate the list of 'other buffers with same purpose' unless we're going to be replacing the buffer. This prevents calculating said list for buffers that aren't being displayed on any window, in particular, background buffers created with `with-temp-buffer` and the like.

Additionally, minor efficiency improvements for calculating buffer purpose are included