### PR TITLE
Delete popup windows when no longer displaying popup buffer

### DIFF
--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -733,6 +733,6 @@ This is implemented by overriding `replace-buffer-in-windows' with
 
 ;;; --- purpose-x-kill ends here ---
 
-(pushnew '(purpose-x-popwin-popup-window . writable) window-persistent-parameters :key #'car)
+(push '(purpose-x-popwin-popup-window . writable) window-persistent-parameters)
 (provide 'window-purpose-x)
 ;;; window-purpose-x.el ends here


### PR DESCRIPTION
Fixes #153 

This is a bit of a hacky workaround for the behaviour of `quit-window`.
When we reuse a popup window to display some other popup buffer, and then we quit from that buffer via `(quit-window t)` or the like, we will be back at our previous popup buffer, and have our quit-restore parameter set to nil.

Unfortunately then, `quit-window` once more will cause the window to display a random buffer because when `quit-restore` is nil, `quit-window` will not actually kill the window because ????