### PR TITLE
Fix setting purpose on magit-related buffers with single-conf

### DIFF
--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -198,7 +198,7 @@ imenu."
                 ;; `magit' purpose). `Magit' doesn't have the same
                 ;; problem (no function is named Magit), so that's why
                 ;; we call the purpose `Magit' and not `magit'.
-                :regexp-purposes '(("^\\*magit" . Magit)))
+                :mode-purposes '((magit-mode . Magit)))
   "Configuration that gives each magit major mode the same purpose.")
 
 (defvar purpose-x-magit-multi-conf


### PR DESCRIPTION
Fixes #155
Magit has changed how they name their buffers and now the regexp approach doesn't work.
All magit-related buffers derive from `magit-mode`, so use that rather than a regex.