### PR TITLE
Properly format defcustom package-version

### DIFF
--- a/window-purpose-configuration.el
+++ b/window-purpose-configuration.el
@@ -129,7 +129,7 @@ purpose of a buffer.  The user configuration and extended configuration
 are used anyway."
   :group 'purpose
   :type 'boolean
-  :package-version "1.2")
+  :package-version '(window-purpose . "1.2"))
 
 (defcustom purpose-user-mode-purposes nil
   "User configured alist mapping of modes to purposes.
@@ -143,7 +143,7 @@ If you set this variable in elisp-code, you should call the function
            (prog1 (set-default symbol value)
              (purpose-compile-user-configuration)))
   :initialize 'custom-initialize-default
-  :package-version "1.2")
+  :package-version '(window-purpose . "1.2"))
 
 (defcustom purpose-user-name-purposes nil
   "User configured alist mapping of names to purposes.
@@ -157,7 +157,7 @@ If you set this variable in elisp-code, you should call the function
            (prog1 (set-default symbol value)
              (purpose-compile-user-configuration)))
   :initialize 'custom-initialize-default
-  :package-version "1.2")
+  :package-version '(window-purpose . "1.2"))
 
 (defcustom purpose-user-regexp-purposes nil
   "User configured alist mapping of regexps to purposes.
@@ -171,7 +171,7 @@ If you set this variable in elisp-code, you should call the function
            (prog1 (set-default symbol value)
              (purpose-compile-user-configuration)))
   :initialize 'custom-initialize-default
-  :package-version "1.2")
+  :package-version '(window-purpose . "1.2"))
 
 (defvar purpose-extended-configuration nil
   "A plist containing `purpose-conf' objects.

--- a/window-purpose-core.el
+++ b/window-purpose-core.el
@@ -33,19 +33,19 @@
   "purpose-mode configuration"
   :group 'windows
   :prefix "purpose-"
-  :package-version "1.2")
+  :package-version '(window-purpose . "1.2"))
 
 (defcustom default-purpose 'general
   "The default purpose for buffers which didn't get another purpose."
   :group 'purpose
   :type 'symbol
-  :package-version "1.2")
+  :package-version '(window-purpose . "1.2"))
 
 (defcustom default-file-purpose 'edit
   "The default purpose for buffers visiting a file which didn't get a purpose."
   :group 'purpose
   :type 'symbol
-  :package-version "1.6.1")
+  :package-version '(window-purpose . "1.6.1"))
 
 ;;; utilities
 

--- a/window-purpose-layout.el
+++ b/window-purpose-layout.el
@@ -40,21 +40,21 @@
   "If nil, don't use layouts from `purpose--built-in-layouts-dir'."
   :group 'purpose
   :type 'boolean
-  :package-version "1.6")
+  :package-version '(window-purpose . "1.6"))
 
 (defcustom purpose-default-layout-file
   (concat user-emacs-directory ".purpose-layout")
   "Default file for saving/loading purpose layout."
   :group 'purpose
   :type 'file
-  :package-version "1.2")
+  :package-version '(window-purpose . "1.2"))
 
 (defcustom purpose-layout-dirs
   (list (locate-user-emacs-file "layouts/"))
   "List of directories containing layout files."
   :group 'purpose
   :type '(repeat file)
-  :package-version "1.5")
+  :package-version '(window-purpose . "1.5"))
 
 (defcustom purpose-get-extra-window-params-functions nil
   "If non-nil, this variable should be a list of functions.
@@ -62,7 +62,7 @@ This variable is used by `purpose-window-params'.  See
 `purpose-window-params' for more details."
   :group 'purpose
   :type 'hook
-  :package-version "1.4")
+  :package-version '(window-purpose . "1.4"))
 
 (defcustom purpose-set-window-properties-functions nil
   "Hook to run after calling `purpose-set-window-properties'.
@@ -75,7 +75,7 @@ WINDOW is nil, your function should act on the selected window
 instead."
   :group 'purpose
   :type 'hook
-  :package-version "1.2")
+  :package-version '(window-purpose . "1.2"))
 
 (defvar purpose-recent-window-layouts (make-ring 50)
   "Most recently used window layouts.

--- a/window-purpose-switch.el
+++ b/window-purpose-switch.el
@@ -55,20 +55,20 @@ Any other value is treated the same as nil."
                  (const error)
                  (const nil)
                  function)
-  :package-version "1.4")
+  :package-version '(window-purpose . "1.4"))
 
 (defcustom purpose-display-buffer-functions nil
   "Hook to run after displaying a buffer with `purpose--action-function'.
 This hook is called with one argument - the window used for display."
   :group 'purpose
   :type 'hook
-  :package-version "1.4")
+  :package-version '(window-purpose . "1.4"))
 
 (defcustom purpose-select-buffer-hook nil
   "Hook to run after selecting a buffer with `purpose-select-buffer'."
   :group 'purpose
   :type 'hook
-  :package-version "1.2")
+  :package-version '(window-purpose . "1.2"))
 
 (defvar purpose--active-p nil
   "When nil, Purpose's advices and `purpose--action-function' are not
@@ -139,7 +139,7 @@ case, `purpose-display-at-top-height' is ignored."
   :group 'purpose
   :type '(choice number
                  (const nil))
-  :package-version "1.4")
+  :package-version '(window-purpose . "1.4"))
 
 (defcustom purpose-display-at-bottom-height 8
   "Height for new windows created by `purpose-display-at-bottom'.
@@ -153,7 +153,7 @@ this case, `purpose-display-at-bottom-height' is ignored."
   :group 'purpose
   :type '(choice number
                  (const nil))
-  :package-version "1.4")
+  :package-version '(window-purpose . "1.4"))
 
 (defcustom purpose-display-at-left-width 32
   "Width for new windows created by `purpose-display-at-left'.
@@ -166,7 +166,7 @@ case, `purpose-display-at-left-width' is ignored."
   :group 'purpose
   :type '(choice number
                  (const nil))
-  :package-version "1.4")
+  :package-version '(window-purpose . "1.4"))
 
 (defcustom purpose-display-at-right-width 32
   "Width for new windows created by `purpose-display-at-right'.
@@ -180,7 +180,7 @@ this case, `purpose-display-at-right-width' is ignored."
   :group 'purpose
   :type '(choice number
                  (const nil))
-  :package-version "1.4")
+  :package-version '(window-purpose . "1.4"))
 
 
 

--- a/window-purpose-utils.el
+++ b/window-purpose-utils.el
@@ -32,7 +32,7 @@
 Toggling this on will cause Purpose to produce some debug messages."
   :group 'purpose
   :type 'boolean
-  :package-version "1.2")
+  :package-version '(window-purpose . "1.2"))
 
 (defun purpose-message (format-string &rest args)
   "Produce a message if `purpose-message-on-p' is non-nil.

--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -302,7 +302,7 @@ compatible with `display-buffer'."
                  (const left)
                  (const right)
                  function)
-  :package-version "1.4")
+  :package-version '(window-purpose . "1.4"))
 
 (defcustom purpose-x-popwin-width 0.4
   "Width of popup window when displayed at left or right.
@@ -311,7 +311,7 @@ Can have the same values as `purpose-display-at-left-width' and
   :group 'purpose
   :type '(choice number
                  (const nil))
-  :package-version "1.4")
+  :package-version '(window-purpose . "1.4"))
 
 (defcustom purpose-x-popwin-height 0.35
   "Height of popup window when displayed at top or bottom.
@@ -320,7 +320,7 @@ Can have the same values as `purpose-display-at-top-height' and
   :group 'purpose
   :type '(choice number
                  (const nil))
-  :package-version "1.4")
+  :package-version '(window-purpose . "1.4"))
 
 (defcustom purpose-x-popwin-major-modes '(help-mode
                                           compilation-mode
@@ -334,7 +334,7 @@ When changing the value of this variable in elisp code, you should call
            (prog1 (set-default symbol value)
              (purpose-x-popwin-update-conf)))
   :initialize 'custom-initialize-default
-  :package-version "1.4")
+  :package-version '(window-purpose . "1.4"))
 
 (defcustom purpose-x-popwin-buffer-names '("*Shell Command Output*")
   "List of buffer names that should be opened as popup windows.
@@ -348,7 +348,7 @@ When changing the value of this variable in elisp code, you should call
            (prog1 (set-default symbol value)
              (purpose-x-popwin-update-conf)))
   :initialize 'custom-initialize-default
-  :package-version "1.4")
+  :package-version '(window-purpose . "1.4"))
 
 (defcustom purpose-x-popwin-buffer-name-regexps nil
   "List of regexp that should be opened as popup windows.
@@ -362,7 +362,7 @@ When changing the value of this variable in elisp code, you should call
            (prog1 (set-default symbol value)
              (purpose-x-popwin-update-conf)))
   :initialize 'custom-initialize-default
-  :package-version "1.4")
+  :package-version '(window-purpose . "1.4"))
 
 (defun purpose-x-popupify-purpose (purpose &optional display-fn)
   "Set up a popup-like behavior for buffers with purpose PURPOSE.


### PR DESCRIPTION
The `:package-version` keyword in `defcustoms` actually takes a [cons cell](https://www.gnu.org/software/emacs/manual/html_node/elisp/Common-Keywords.html#Common-Keywords). The way it is now is breaking [helpful-variable](https://github.com/Wilfred/helpful/blob/master/helpful.el#L1267) when describing the purpose variables.