### PR TITLE
Fix dangling popup

### DIFF
--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -172,7 +172,7 @@ If current buffer doesn't have a filename, do nothing."
                 (add-minor-mode 'dired-hide-details-mode ""))
               (dired-hide-details-mode)))
           ;; Prevents immediately closing the newly created popup help window
-          (letf (((symbol-value 'purpose-select-buffer-hook) nil))
+          (cl-letf (((symbol-value 'purpose-select-buffer-hook) nil))
             (display-buffer buffer))
           (bury-buffer buffer)
           (when purpose-x-code1-dired-goto-file

--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -179,7 +179,8 @@ If current buffer doesn't have a filename, do nothing."
             (setq truncate-lines t
                   word-wrap nil
                   visual-line-mode nil
-                  mode-line-format nil)
+                  mode-line-format nil
+                  auto-revert-verbose nil)
             (when (fboundp 'dired-hide-details-mode)
               (when (not (assq 'dired-hide-details-mode minor-mode-alist))
                 (add-minor-mode 'dired-hide-details-mode ""))

--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -159,7 +159,10 @@ If current buffer doesn't have a filename, do nothing."
   "Update auxiliary buffers if frame/buffer had changed.
 Uses `frame-or-buffer-changed-p' to determine whether the frame or
 buffer had changed."
-  (when (frame-or-buffer-changed-p 'purpose-x-code1-buffers-changed)
+  (when (and
+         (frame-or-buffer-changed-p 'purpose-x-code1-buffers-changed)
+         (not (memq (purpose-buffer-purpose (current-buffer)) '(code1-dired buffers ilist)))
+         (not (minibufferp)))
     (purpose-x-code1-update-dired)
     (imenu-list-update-safe)))
 

--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -193,10 +193,10 @@ If current buffer doesn't have a filename, do nothing."
 
 (defun purpose-x-code1-update-changed ()
   "Update auxiliary buffers if frame/buffer had changed."
-  (when (and (not (eq (current-buffer) (get-buffer imenu-list-buffer-name)))
+  (when (and (not (minibufferp))
+             (not (eq (current-buffer) (get-buffer imenu-list-buffer-name)))
              (or (frame-or-buffer-changed-p 'purpose-x-code1-buffers-changed)
-                 (and (not (minibufferp))
-                      (not (memq (purpose-buffer-purpose (current-buffer)) '(code1-dired buffers ilist))))))
+                 (not (memq (purpose-buffer-purpose (current-buffer)) '(code1-dired buffers ilist)))))
     (purpose-x-code1-update-dired)
     (imenu-list-update)))
 

--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -105,6 +105,10 @@ All windows are purpose-dedicated.")
   ()
   (buffer-file-name buf))
 
+(defun purpose-x-code1-ibuffer-shut-up-advice (oldfun &rest args)
+  "Shut up `ibuffer-redisplay' and `ibuffer-update'"
+  (shut-up (apply oldfun args)))
+
 (defun purpose-x-code1--setup-ibuffer ()
   "Set up ibuffer settings."
   (add-hook 'ibuffer-mode-hook
@@ -118,6 +122,8 @@ All windows are purpose-dedicated.")
   ;; (setq ibuffer-default-shrink-to-minimum-size t)
   (when (get-buffer "*Ibuffer*")
     (kill-buffer "*Ibuffer*"))
+  (advice-add 'ibuffer-redisplay :around 'purpose-x-code1-ibuffer-shut-up-advice)
+  (advice-add 'ibuffer-update :around 'purpose-x-code1-ibuffer-shut-up-advice)
   (save-selected-window
     (ibuffer-list-buffers)
     (let ((ibuf (get-buffer "*Ibuffer*")))
@@ -130,6 +136,8 @@ All windows are purpose-dedicated.")
 
 (defun purpose-x-code1--unset-ibuffer ()
   "Unset ibuffer settings."
+  (advice-remove 'ibuffer-redisplay 'purpose-x-code1-ibuffer-shut-up-advice)
+  (advice-remove 'ibuffer-update 'purpose-x-code1-ibuffer-shut-up-advice)
   (remove-hook 'ibuffer-mode-hook
                #'(lambda ()
                    (ibuffer-filter-by-purpose-x-code1-ibuffer-files-only nil)))

--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -208,8 +208,9 @@ If current buffer doesn't have a filename, do nothing."
   (let ((wrapper (lambda ()
                    (unwind-protect
                        (purpose-x-code1-update-changed)
-                     (cancel-timer purpose-x-code1-post-command-action-timer)
-                     (setq purpose-x-code1-post-command-action-timer nil)))))
+                     (when (timerp purpose-x-code1-post-command-action-timer)
+                       (cancel-timer purpose-x-code1-post-command-action-timer)
+                       (setq purpose-x-code1-post-command-action-timer nil))))))
     (setq purpose-x-code1-post-command-action-timer
           (run-with-idle-timer purpose-x-code1-update-idle-delay nil wrapper))))
 

--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -150,6 +150,8 @@ If current buffer doesn't have a filename, do nothing."
             (with-current-buffer buffer
               (rename-buffer purpose-x-code1-dired-buffer-name)
               (when (fboundp 'dired-hide-details-mode)
+                (when (not (assq 'dired-hide-details-mode minor-mode-alist))
+                  (add-minor-mode 'dired-hide-details-mode ""))
                 (dired-hide-details-mode)))
             (display-buffer buffer)
             (dired-goto-file file-path)

--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -227,12 +227,14 @@ imenu."
   (purpose-x-code1--setup-imenu-list)
   (frame-or-buffer-changed-p 'purpose-x-code1-buffers-changed)
   (purpose-set-window-layout purpose-x-code1--window-layout)
+  (add-hook 'post-command-hook #'purpose-x-code1-update-changed)
   (add-hook 'window-configuration-change-hook #'purpose-x-code1-update-changed))
 
 (defun purpose-x-code1-unset ()
   "Unset purpose-x-code1."
   (interactive)
   (remove-hook 'window-configuration-change-hook #'purpose-x-code1-update-changed)
+  (remove-hook 'post-command-hook #'purpose-x-code1-update-changed)
   (purpose-x-code1--unset-imenu-list)
   (purpose-x-code1--unset-ibuffer)
   (purpose-del-extension-configuration :purpose-x-code1))

--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -184,12 +184,12 @@ If current buffer doesn't have a filename, do nothing."
             (when (fboundp 'dired-hide-details-mode)
               (when (not (assq 'dired-hide-details-mode minor-mode-alist))
                 (add-minor-mode 'dired-hide-details-mode ""))
-              (dired-hide-details-mode)))
+              (dired-hide-details-mode))
+            (when purpose-x-code1-dired-goto-file
+              (dired-goto-file file-path)))
           ;; Prevents immediately closing the newly created popup help window
           (cl-letf (((symbol-value 'purpose-select-buffer-hook) nil))
-            (display-buffer buffer))
-          (when purpose-x-code1-dired-goto-file
-            (dired-goto-file file-path)))))))
+            (display-buffer buffer)))))))
 
 (defun purpose-x-code1-update-changed ()
   "Update auxiliary buffers if frame/buffer had changed."

--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -51,12 +51,18 @@
 (require 'ibuf-ext)
 (require 'imenu-list)
 
+(defcustom purpose-x-code1-dired-buffer-name "*Files*"
+  "The buffer name used for the `dired' buffer specific to Code1 extension."
+  :group 'purpose
+  :type '(string)
+  :package-version "1.5")
+
 (defvar purpose-x-code1--window-layout
   '(nil
     (0 0 152 35)
     (t
      (0 0 29 35)
-     (:purpose dired :purpose-dedicated t :width 0.16 :height 0.5 :edges
+     (:purpose code1-dired :purpose-dedicated t :width 0.16 :height 0.5 :edges
                (0.0 0.0 0.19333333333333333 0.5))
      (:purpose buffers :purpose-dedicated t :width 0.16 :height 0.4722222222222222 :edges
                (0.0 0.5 0.19333333333333333 0.9722222222222222)))
@@ -65,7 +71,7 @@
     (:purpose ilist :purpose-dedicated t :width 0.15333333333333332 :height 0.9722222222222222 :edges
               (0.8266666666666667 0.0 1.0133333333333334 0.9722222222222222)))
   "Window layout for purpose-x-code1-dired-ibuffer.
-Has a main 'edit window, and two side windows - 'dired and 'buffers.
+Has a main 'edit window, and two side windows - 'code1-dired and 'buffers.
 All windows are purpose-dedicated.")
 
 ;; the name arg ("purpose-x-code1") is necessary for Emacs 24.5 and older
@@ -74,8 +80,9 @@ All windows are purpose-dedicated.")
   (purpose-conf "purpose-x-code1"
                 :mode-purposes
                 '((ibuffer-mode . buffers)
-                  (dired-mode . dired)
-                  (imenu-list-major-mode . ilist))))
+                  (imenu-list-major-mode . ilist))
+                :name-purposes
+                `((,purpose-x-code1-dired-buffer-name . code1-dired))))
 
 (defvar purpose-x-code1-buffers-changed nil
   "Internal variable for use with `frame-or-buffer-changed-p'.")
@@ -126,16 +133,27 @@ If a non-buffer-dedicated window with purpose 'dired exists, display
 the directory of the current buffer in that window, using `dired'.
 If there is no window available, do nothing.
 If current buffer doesn't have a filename, do nothing."
-  (when (and (buffer-file-name)
-             (cl-delete-if #'window-dedicated-p
-                           (purpose-windows-with-purpose 'dired)))
-    (save-selected-window
-      (let ((buffer (dired-noselect (file-name-directory (buffer-file-name)))))
-        (with-current-buffer buffer
-          (when (fboundp 'dired-hide-details-mode)
-            (dired-hide-details-mode)))
-        (display-buffer buffer))
-      (bury-buffer (current-buffer)))))
+(save-selected-window
+    (let ((file-path (buffer-file-name)))
+      (when (and file-path
+                 (cl-delete-if #'window-dedicated-p
+                               (purpose-windows-with-purpose 'code1-dired)))
+        ;; Prevents immediately closing the newly created popup help window
+        (letf (((symbol-value 'purpose-select-buffer-hook) nil))
+          (let ((buffer (dired-noselect (file-name-directory file-path))))
+            ;; Make sure code1 only creates 1 dired buffer
+            (dolist (other-buf (purpose-buffers-with-purpose 'code1-dired))
+              (when (and (not (eq buffer other-buf))
+                         (not (string= (buffer-name other-buf)
+                                       (purpose--dummy-buffer-name 'code1-dired))))
+                (kill-buffer other-buf)))
+            (with-current-buffer buffer
+              (rename-buffer purpose-x-code1-dired-buffer-name)
+              (when (fboundp 'dired-hide-details-mode)
+                (dired-hide-details-mode)))
+            (display-buffer buffer)
+            (dired-goto-file file-path)
+            (bury-buffer (current-buffer))))))))
 
 (defun purpose-x-code1-update-changed ()
   "Update auxiliary buffers if frame/buffer had changed.
@@ -150,7 +168,7 @@ buffer had changed."
   "Setup purpose-x-code1.
 This setup includes 4 windows:
 1. dedicated 'edit window
-2. dedicated 'dired window.  This window shows the current buffer's
+2. dedicated 'code1-dired window.  This window shows the current buffer's
 directory in a special window, using `dired' and
 `dired-hide-details-mode' (if available).
 3. dedicated 'buffers window.  This window shows the currently open

--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -160,6 +160,7 @@ If current buffer doesn't have a filename, do nothing."
                        (not (string= (buffer-name other-buf)
                                      (purpose--dummy-buffer-name 'code1-dired))))
               (kill-buffer other-buf)))
+          ;; Set up local vars
           (with-current-buffer buffer
             (rename-buffer purpose-x-code1-dired-buffer-name)
             (setq truncate-lines t
@@ -196,6 +197,8 @@ If current buffer doesn't have a filename, do nothing."
   (imenu-list-stop-timer)
   (with-current-buffer (get-buffer imenu-list-buffer-name)
     (setq truncate-lines t
+          word-wrap nil
+          visual-line-mode nil
           mode-line-format nil)))
 
 (defun purpose-x-code1--unset-imenu-list ()

--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -174,8 +174,9 @@ If current buffer doesn't have a filename, do nothing."
           ;; Prevents immediately closing the newly created popup help window
           (letf (((symbol-value 'purpose-select-buffer-hook) nil))
             (display-buffer buffer))
-          (dired-goto-file file-path)
-          (bury-buffer (current-buffer)))))))
+          (bury-buffer buffer)
+          (when purpose-x-code1-dired-goto-file
+            (dired-goto-file file-path)))))))
 
 (defun purpose-x-code1-update-changed ()
   "Update auxiliary buffers if frame/buffer had changed."

--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -186,8 +186,6 @@ If current buffer doesn't have a filename, do nothing."
           (cl-letf (((symbol-value 'purpose-select-buffer-hook) nil))
             (display-buffer buffer)))))))
 
-(defvar purpose-x-code1-post-command-action-timer nil)
-
 (defun purpose-x-code1-update-changed ()
   "Update auxiliary buffers if frame/buffer had changed."
   (while-no-input

--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -193,12 +193,14 @@ If current buffer doesn't have a filename, do nothing."
 
 (defun purpose-x-code1-update-changed ()
   "Update auxiliary buffers if frame/buffer had changed."
-  (when (and (not (minibufferp))
-             (not (eq (current-buffer) (get-buffer imenu-list-buffer-name)))
-             (or (frame-or-buffer-changed-p 'purpose-x-code1-buffers-changed)
-                 (not (memq (purpose-buffer-purpose (current-buffer)) '(code1-dired buffers ilist)))))
-    (purpose-x-code1-update-dired)
-    (imenu-list-update)))
+  (while-no-input
+    (redisplay)
+    (when (and (not (minibufferp))
+               (not (eq (current-buffer) (get-buffer imenu-list-buffer-name)))
+               (or (frame-or-buffer-changed-p 'purpose-x-code1-buffers-changed)
+                   (not (memq (purpose-buffer-purpose (current-buffer)) '(code1-dired buffers ilist)))))
+      (purpose-x-code1-update-dired)
+      (imenu-list-update))))
 
 (defvar purpose-x-code1-post-command-action-timer nil)
 
@@ -256,14 +258,14 @@ imenu."
   (purpose-x-code1--setup-imenu-list)
   (frame-or-buffer-changed-p 'purpose-x-code1-buffers-changed)
   (purpose-set-window-layout purpose-x-code1--window-layout)
-  (add-hook 'post-command-hook #'purpose-x-code1-debounced-update-changed)
+  (add-hook 'post-command-hook #'purpose-x-code1-update-changed)
   (add-hook 'window-configuration-change-hook #'purpose-x-code1-debounced-update-changed))
 
 (defun purpose-x-code1-unset ()
   "Unset purpose-x-code1."
   (interactive)
   (remove-hook 'window-configuration-change-hook #'purpose-x-code1-debounced-update-changed)
-  (remove-hook 'post-command-hook #'purpose-x-code1-debounced-update-changed)
+  (remove-hook 'post-command-hook #'purpose-x-code1-update-changed)
   (purpose-x-code1--unset-imenu-list)
   (purpose-x-code1--unset-ibuffer)
   (purpose-del-extension-configuration :purpose-x-code1))

--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -65,11 +65,6 @@ in `dired' using `dired-goto-file'."
   :type 'boolean
   :package-version "1.6.2")
 
-(defcustom purpose-x-code1-update-idle-delay 1
-  "Time in seconds after idling before updating code1."
-  :group 'purpose
-  :type 'number)
-
 (defvar purpose-x-code1--window-layout
   '(nil
     (0 0 152 35)

--- a/window-purpose-x.el
+++ b/window-purpose-x.el
@@ -133,29 +133,29 @@ If a non-buffer-dedicated window with purpose 'dired exists, display
 the directory of the current buffer in that window, using `dired'.
 If there is no window available, do nothing.
 If current buffer doesn't have a filename, do nothing."
-(save-selected-window
+  (save-selected-window
     (let ((file-path (buffer-file-name)))
       (when (and file-path
                  (cl-delete-if #'window-dedicated-p
                                (purpose-windows-with-purpose 'code1-dired)))
-        ;; Prevents immediately closing the newly created popup help window
-        (letf (((symbol-value 'purpose-select-buffer-hook) nil))
-          (let ((buffer (dired-noselect (file-name-directory file-path))))
-            ;; Make sure code1 only creates 1 dired buffer
-            (dolist (other-buf (purpose-buffers-with-purpose 'code1-dired))
-              (when (and (not (eq buffer other-buf))
-                         (not (string= (buffer-name other-buf)
-                                       (purpose--dummy-buffer-name 'code1-dired))))
-                (kill-buffer other-buf)))
-            (with-current-buffer buffer
-              (rename-buffer purpose-x-code1-dired-buffer-name)
-              (when (fboundp 'dired-hide-details-mode)
-                (when (not (assq 'dired-hide-details-mode minor-mode-alist))
-                  (add-minor-mode 'dired-hide-details-mode ""))
-                (dired-hide-details-mode)))
-            (display-buffer buffer)
-            (dired-goto-file file-path)
-            (bury-buffer (current-buffer))))))))
+        (let ((buffer (dired-noselect (file-name-directory file-path))))
+          ;; Make sure code1 only creates 1 dired buffer
+          (dolist (other-buf (purpose-buffers-with-purpose 'code1-dired))
+            (when (and (not (eq buffer other-buf))
+                       (not (string= (buffer-name other-buf)
+                                     (purpose--dummy-buffer-name 'code1-dired))))
+              (kill-buffer other-buf)))
+          (with-current-buffer buffer
+            (rename-buffer purpose-x-code1-dired-buffer-name)
+            (when (fboundp 'dired-hide-details-mode)
+              (when (not (assq 'dired-hide-details-mode minor-mode-alist))
+                (add-minor-mode 'dired-hide-details-mode ""))
+              (dired-hide-details-mode)))
+          ;; Prevents immediately closing the newly created popup help window
+          (letf (((symbol-value 'purpose-select-buffer-hook) nil))
+            (display-buffer buffer))
+          (dired-goto-file file-path)
+          (bury-buffer (current-buffer)))))))
 
 (defun purpose-x-code1-update-changed ()
   "Update auxiliary buffers if frame/buffer had changed.

--- a/window-purpose.el
+++ b/window-purpose.el
@@ -7,7 +7,7 @@
 ;; Version: 1.7
 ;; Keywords: frames
 ;; Homepage: https://github.com/bmag/emacs-purpose
-;; Package-Requires: ((emacs "24.4") (let-alist "1.0.3") (imenu-list "0.1"))
+;; Package-Requires: ((emacs "24.4") (let-alist "1.0.3") (imenu-list "0.1") (shut-up "0.3.2"))
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
According to the [elisp manual](https://www.gnu.org/software/emacs/manual/html_node/elisp/Quitting-Windows.html#Quitting-Windows), when a window isn't deleted after a `quit-restore-window` is run (which is called from `quit-window`, which is bound to `q` on a lot of popup-y modes), it's previous buffer will be used to replace the current buffer and the `quit-restore` window parameter set to `nil. When this parameter is `nil` and there are't previous buffers can be shown, then we should be sure to know we've just killed the last popup buffer in this window, and this window can thus be closed.