### PR TITLE
Toggle fixes when purpose-mode is toggled

### DIFF
--- a/window-purpose.el
+++ b/window-purpose.el
@@ -298,13 +298,13 @@ This function is called when `purpose-mode' is deactivated."
         (setq display-buffer-overriding-action
               '(purpose--action-function . nil))
         (setq purpose--active-p t)
-        (unless purpose-fix-togglers
+        (unless purpose-fix-togglers-hook
           (purpose-fix-install))
-        (run-hooks 'purpose-fix-togglers))
+        (run-hooks 'purpose-fix-togglers-hook))
 
     (purpose--remove-advices)
     (setq purpose--active-p nil)
-    (run-hooks 'purpose-fix-togglers)))
+    (run-hooks 'purpose-fix-togglers-hook)))
 
 (push '(purpose-dedicated . writable) window-persistent-parameters)
 (provide 'window-purpose)

--- a/window-purpose.el
+++ b/window-purpose.el
@@ -298,9 +298,13 @@ This function is called when `purpose-mode' is deactivated."
         (setq display-buffer-overriding-action
               '(purpose--action-function . nil))
         (setq purpose--active-p t)
-        (purpose-fix-install))
+        (unless purpose-fix-togglers
+          (purpose-fix-install))
+        (run-hooks 'purpose-fix-togglers))
+
     (purpose--remove-advices)
-    (setq purpose--active-p nil)))
+    (setq purpose--active-p nil)
+    (run-hooks 'purpose-fix-togglers)))
 
 (push '(purpose-dedicated . writable) window-persistent-parameters)
 (provide 'window-purpose)


### PR DESCRIPTION
Toggle the integration fixes on when purpose-mode is activated, and toggle them
off when purpose-mode is deactivated. Mainly, this means the relevant advices
are now active only while purpose-mode is active.

Fixes #166 