### PR TITLE
Integrate debug with purpose

### DIFF
--- a/window-purpose-fixes.el
+++ b/window-purpose-fixes.el
@@ -77,7 +77,7 @@ SYMBOL WHERE and FUNCTION have the same meaning as `advice-add'."
                      (funcall pop-to-buffer-definition buffer))))
           (apply fn args))))
 
-    (purpose-install-advice-toggler 'debug :around 'purpose--debug)))
+    (purpose-fix-install-advice-toggler #'debug :around #'purpose--debug)))
 
 (defun purpose--fix-edebug ()
   "Integrates Edebug with Purpose."

--- a/window-purpose-fixes.el
+++ b/window-purpose-fixes.el
@@ -65,6 +65,20 @@ SYMBOL WHERE and FUNCTION have the same meaning as `advice-add'."
            (purpose-fix-toggle-advice ,symbol ,where ,function)))
        (add-hook 'purpose-fix-togglers-hook #',toggler-name))))
 
+(defun purpose--fix-debug ()
+  "Integrates `debug' with Purpose."
+
+  (with-eval-after-load 'debug
+    (defun purpose--debug (fn &rest args)
+      "Ignore `pop-to-buffer' display actions given by `debug'."
+      (let ((pop-to-buffer-definition (symbol-function 'pop-to-buffer)))
+        (cl-letf (((symbol-function 'pop-to-buffer)
+                   (lambda (buffer &optional _action _record)
+                     (funcall pop-to-buffer-definition buffer))))
+          (apply fn args))))
+
+    (purpose-install-advice-toggler 'debug :around 'purpose--debug)))
+
 (defun purpose--fix-edebug ()
   "Integrates Edebug with Purpose."
 
@@ -387,6 +401,7 @@ Don't call this function before `popwin' is loaded."
   "Install fixes for integrating Purpose with other features.
 EXCLUDE is a list of integrations to skip.  Known members of EXCLUDE
 are:
+- 'debug : don't integrate with debug
 - 'edebug : don't integrate with edebug
 - 'compilation-next-error-function : don't integrate with
   `compilation-next-error-function'.
@@ -401,6 +416,8 @@ are:
 - 'which-key : don't integrate with which-key
 - 'whitespace : don't integrate with whitespace"
   (interactive)
+  (unless (member 'debug exclude)
+    (purpose--fix-debug))
   (unless (member 'edebug exclude)
     (purpose--fix-edebug))
   (unless (member 'compilation-next-error-function exclude)


### PR DESCRIPTION
`debug` supplies its own display actions to `pop-to-buffer` in order to reuse a window, which usually isn't what we want to do when there are multiple split windows, some of which maybe too small for a debug backtrace buffer. This PR hands the control of window picking back to purpose.