### PR TITLE
Fix CI: don't fail fast, and really allow failure on emacs-snapshot

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
             allow_failures: true
         cask_version:
           - 'snapshot'
+      fail-fast: false
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
           - '27.1'
         include:
           - emacs_version: snapshot
-            allow_failures: true
+            continue-on-error: true
         cask_version:
           - 'snapshot'
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,17 +17,15 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         emacs_version:
           - '25.3'
           - '26.3'
           - '27.1'
-        experimental: [false]
         include:
           - emacs_version: snapshot
-            experimental: true
+            continue-on-error: true
         cask_version:
           - 'snapshot'
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,15 +17,17 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         emacs_version:
           - '25.3'
           - '26.3'
           - '27.1'
+        experimental: [false]
         include:
           - emacs_version: snapshot
-            continue-on-error: true
+            experimental: true
         cask_version:
           - 'snapshot'
       fail-fast: false


### PR DESCRIPTION
Before, any failure, even against emacs-snapshot, would cancel all remaining jobs and mark the test ("workflow") as failed. This PR it partially.

Sometimes we need to compare between Emacs versions. With `fail-fast` set to `true` (the default), failure in one Emacs version cancels the remaining jobs for other Emacs versions. That's why we now set `fail-fast` to `false`.

Additionally, `allow_failures` from Travis CI is called `continue-on-error` in Github Actions.

Situation before:
- failure against any emacs version cancels all unfinished jobs
- failure against emacs-snapshot marks the entire test as failed, resulting in:
  - an automatic email sent to me
  - a red "x" mark in the "Actions" tab
  - a red "x" mark in the PR page and commit page

Situation after:
- jobs for all emacs versions run until success/failure, even if another job fails
- failure against emacs-snapshot mostly marks the entire test as passed:
  - no automatic emails (yay)
  - a green "v" mark in the "Actions" tab (yay)
  - a red "x" mark in the PR page and commit page (should be a green "v" or some other *suitable* indication, waiting on Github to fix this bug, see https://github.com/actions/toolkit/issues/399)

This PR seems to fix the CI and the pass/fail marks as much as possible on our side. The remaining misleading red "x" mark is a bug in Github's interface (see https://github.com/actions/toolkit/issues/399)
.