### PR TITLE
Only dedicate compilation buffer if it is being displayed

### DIFF
--- a/window-purpose-fixes.el
+++ b/window-purpose-fixes.el
@@ -113,10 +113,12 @@ duration of the function."
 
       (let* ((compilation-window (get-buffer-window (marker-buffer (point-marker))))
              (old-window-dedicated-p (window-dedicated-p compilation-window)))
-        (set-window-dedicated-p compilation-window t)
-        (unwind-protect
+        (if (not compilation-window)
             (apply oldfun args)
-          (set-window-dedicated-p compilation-window old-window-dedicated-p))))
+          (set-window-dedicated-p compilation-window t)
+          (unwind-protect
+              (apply oldfun args)
+            (set-window-dedicated-p compilation-window old-window-dedicated-p)))))
 
     (purpose-fix-install-advice-toggler
      #'compilation-next-error-function


### PR DESCRIPTION
Fixes #186.

When the compilation buffer is not displayed at the time `next-error`
is invoked, then `compilation-window` ends up nil, and
`window-dedicated-p` and `set-window-dedicated-p` end up operating on
whatever window happens to be selected.

This ends up being two different windows if `next-error` moves to a
different buffer, and so the dedicated-ness of the windows is not
correctly preserved.

Fix by only attempting to make the window dedicated if
`compilation-window` is non-nil.